### PR TITLE
Use type-independent image functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,20 +23,18 @@ require_once 'vendor/autoload.php';
 use kornrunner\Blurhash\Blurhash;
 
 $file  = 'test/data/img1.jpg';
-$image = imagecreatefromjpeg($file);
-list($width, $height) = getimagesize($file);
+$image = imagecreatefromstring(file_get_contents($file));
+$width = imagesx($image);
+$height = imagesy($image);
 
 $pixels = [];
 for ($y = 0; $y < $height; ++$y) {
     $row = [];
     for ($x = 0; $x < $width; ++$x) {
-        $rgb = imagecolorat($image, $x, $y);
+        $index = imagecolorat($image, $x, $y);
+        $colors = imagecolorsforindex($image, $index);
 
-        $r = ($rgb >> 16) & 0xFF;
-        $g = ($rgb >> 8) & 0xFF;
-        $b = $rgb & 0xFF;
-
-        $row[] = [$r, $g, $b];
+        $row[] = [$colors['red'], $colors['green'], $colors['blue']];
     }
     $pixels[] = $row;
 }

--- a/test/BlurhashTest.php
+++ b/test/BlurhashTest.php
@@ -72,19 +72,18 @@ class BlurhashTest extends TestCase {
     }
 
     private function getImagePixels($file) {
-        $image = imagecreatefromjpeg($file);
-        list ($width, $height) = getimagesize($file);
+        $image = imagecreatefromstring(file_get_contents($file));
+        $width = imagesx($image);
+        $height = imagesy($image);
+
         $pixels = [];
         for ($y = 0; $y < $height; ++$y) {
             $row = [];
             for ($x = 0; $x < $width; ++$x) {
-                $rgb = imagecolorat($image, $x, $y);
+                $index = imagecolorat($image, $x, $y);
+                $colors = imagecolorsforindex($image, $index);
 
-                $r = ($rgb >> 16) & 0xFF;
-                $g = ($rgb >> 8) & 0xFF;
-                $b = $rgb & 0xFF;
-
-                $row[] = [$r, $g, $b];
+                $row[] = [$colors['red'], $colors['green'], $colors['blue']];
             }
 
             $pixels[] = $row;


### PR DESCRIPTION
Greetings 👋!

Using `imagecreatefromstring()` instead of `imagecreatefromjpeg()` would prevent developers seeking to use this library from thinking about "but what if I want to use PNG or GIF images?"

Using `imagecolorsforindex()` instead of bit-shifting would reduce the mental overhead even further (just speaking from my own experience 🙈)

(Tested by adapting the tests to match the usage examples)

:octocat: